### PR TITLE
Draft: Add event recorder for dispatcher cache

### DIFF
--- a/pkg/dispatcher/cache/utils/utils.go
+++ b/pkg/dispatcher/cache/utils/utils.go
@@ -25,10 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	volcanoclientset "volcano.sh/apis/pkg/client/clientset/versioned"
-
-	"volcano.sh/volcano-global/pkg/utils"
 )
 
 // CreateDefaultQueue Create the default queue.
@@ -46,7 +45,7 @@ func CreateDefaultQueue(volcanoClient volcanoclientset.Interface, queueName stri
 				Name: queueName,
 			},
 			Spec: schedulingv1beta1.QueueSpec{
-				Reclaimable: utils.ToPointer(true),
+				Reclaimable: ptr.To(true),
 				Weight:      1,
 			},
 		}, metav1.CreateOptions{})

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,7 +15,3 @@ limitations under the License.
 */
 
 package utils
-
-func ToPointer[T any](c T) *T {
-	return &c
-}

--- a/pkg/webhooks/resourcebinding/mutating/mutating.go
+++ b/pkg/webhooks/resourcebinding/mutating/mutating.go
@@ -25,6 +25,7 @@ import (
 	registrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"volcano.sh/volcano/pkg/webhooks/router"
 	"volcano.sh/volcano/pkg/webhooks/util"
 
@@ -97,6 +98,6 @@ func ResourceBindings(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResp
 		return util.ToAdmissionResponse(err)
 	}
 
-	response.PatchType = utils.ToPointer(admissionv1.PatchTypeJSONPatch)
+	response.PatchType = ptr.To(admissionv1.PatchTypeJSONPatch)
 	return response
 }

--- a/pkg/webhooks/resourcebinding/mutating/mutating_test.go
+++ b/pkg/webhooks/resourcebinding/mutating/mutating_test.go
@@ -28,8 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/utils/ptr"
 
-	"volcano.sh/volcano-global/pkg/utils"
 	"volcano.sh/volcano-global/pkg/webhooks/decoder"
 )
 
@@ -89,7 +89,7 @@ func TestResourceBindings(t *testing.T) {
 			expectResponse: admissionv1.AdmissionResponse{
 				Allowed:   true,
 				Patch:     normalResponsePatch,
-				PatchType: utils.ToPointer(admissionv1.PatchTypeJSONPatch),
+				PatchType: ptr.To(admissionv1.PatchTypeJSONPatch),
 			},
 		},
 		{


### PR DESCRIPTION
Add event recorder for dispatcher cache, and use `ptr.To` to replace `utils.ToPointer`.