### PR TITLE
[WIP] support for more workloads

### DIFF
--- a/pkg/workload/cronjob.go
+++ b/pkg/workload/cronjob.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workload
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano-global/pkg/utils"
+)
+
+// init is called automatically during package initialization to register the CronJob workload.
+func init() {
+	Register(cronJobGVK, NewCronJobWorkload)
+}
+
+var cronJobGVK = batchv1.SchemeGroupVersion.WithKind("CronJob")
+
+// CronJobWorkload is the implementation of the Workload interface for CronJob resources.
+type CronJobWorkload struct {
+	resource *batchv1.CronJob
+}
+
+// NewCronJobWorkload creates a CronJob workload from an unstructured object.
+func NewCronJobWorkload(obj *unstructured.Unstructured) (Workload, error) {
+	var cj batchv1.CronJob
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &cj)
+	if err != nil {
+		klog.ErrorS(err, "Failed to convert to cronjob workload")
+		return nil, err
+	}
+	return &CronJobWorkload{resource: &cj}, nil
+}
+
+// QueueName returns the name of the queue the cronjob belongs to.
+func (cj *CronJobWorkload) QueueName() string {
+	return utils.GetObjQueue(cj.resource.Spec.JobTemplate.Spec.Template.GetObjectMeta())
+}
+
+// PriorityClassName returns the priority class name of the cronjob.
+func (cj *CronJobWorkload) PriorityClassName() string {
+	return cj.resource.Spec.JobTemplate.Spec.Template.Spec.PriorityClassName
+}

--- a/pkg/workload/daemonset.go
+++ b/pkg/workload/daemonset.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workload
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano-global/pkg/utils"
+)
+
+// init is called automatically during package initialization to register the DaemonSet workload.
+func init() {
+	Register(daemonSetGVK, NewDaemonSetWorkload)
+}
+
+var daemonSetGVK = appsv1.SchemeGroupVersion.WithKind("DaemonSet")
+
+// DaemonSetWorkload is the implementation of the Workload interface for DaemonSet resources.
+type DaemonSetWorkload struct {
+	resource *appsv1.DaemonSet
+}
+
+// NewDaemonSetWorkload creates a DaemonSet workload from an unstructured object.
+func NewDaemonSetWorkload(obj *unstructured.Unstructured) (Workload, error) {
+	var ds appsv1.DaemonSet
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &ds)
+	if err != nil {
+		klog.ErrorS(err, "Failed to convert to daemonset workload")
+		return nil, err
+	}
+	return &DaemonSetWorkload{resource: &ds}, nil
+}
+
+// QueueName returns the name of the queue the daemonset belongs to.
+func (d DaemonSetWorkload) QueueName() string {
+	return utils.GetObjQueue(d.resource.Spec.Template.GetObjectMeta())
+}
+
+// PriorityClassName returns the priority class name of the daemonset.
+func (d DaemonSetWorkload) PriorityClassName() string {
+	return d.resource.Spec.Template.Spec.PriorityClassName
+}

--- a/pkg/workload/job.go
+++ b/pkg/workload/job.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workload
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano-global/pkg/utils"
+)
+
+// init is called automatically during package initialization to register the Job workload.
+func init() {
+	Register(jobGVK, NewJobWorkload)
+}
+
+var jobGVK = batchv1.SchemeGroupVersion.WithKind("Job")
+
+// JobWorkload is the implementation of the Workload interface for Job resources.
+type JobWorkload struct {
+	resource *batchv1.Job
+}
+
+// NewJobWorkload creates a Job workload from an unstructured object.
+func NewJobWorkload(obj *unstructured.Unstructured) (Workload, error) {
+	var job batchv1.Job
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &job)
+	if err != nil {
+		klog.ErrorS(err, "Failed to convert to job workload")
+		return nil, err
+	}
+	return &JobWorkload{resource: &job}, nil
+}
+
+// QueueName returns the name of the queue the job belongs to.
+func (j *JobWorkload) QueueName() string {
+	return utils.GetObjQueue(j.resource.Spec.Template.GetObjectMeta())
+}
+
+// PriorityClassName returns the priority class name of the job.
+func (j *JobWorkload) PriorityClassName() string {
+	return j.resource.Spec.Template.Spec.PriorityClassName
+}

--- a/pkg/workload/statefulset.go
+++ b/pkg/workload/statefulset.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workload
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano-global/pkg/utils"
+)
+
+// init is called automatically during package initialization to register the StatefulSet workload.
+func init() {
+	Register(statefulSetGVK, NewStatefulSetWorkload)
+}
+
+var statefulSetGVK = appsv1.SchemeGroupVersion.WithKind("StatefulSet")
+
+// StatefulSetWorkload is the implementation of the Workload interface for StatefulSet resources.
+type StatefulSetWorkload struct {
+	resource *appsv1.StatefulSet
+}
+
+// NewStatefulSetWorkload creates a StatefulSet workload from an unstructured object.
+func NewStatefulSetWorkload(obj *unstructured.Unstructured) (Workload, error) {
+	var sts appsv1.StatefulSet
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &sts)
+	if err != nil {
+		klog.ErrorS(err, "Failed to convert to statefulset workload")
+		return nil, err
+	}
+	return &StatefulSetWorkload{resource: &sts}, nil
+}
+
+// QueueName returns the name of the queue the statefulset belongs to.
+func (s *StatefulSetWorkload) QueueName() string {
+	return utils.GetObjQueue(s.resource.Spec.Template.GetObjectMeta())
+}
+
+// PriorityClassName returns the priority class name of the statefulset.
+func (s *StatefulSetWorkload) PriorityClassName() string {
+	return s.resource.Spec.Template.Spec.PriorityClassName
+}


### PR DESCRIPTION
issue: https://github.com/volcano-sh/volcano/issues/4297

supports
- cronjob
- daemonset
- job
- statefulset

For spark workload, I'm using `https://github.com/kubeflow/spark-operator/blob/master/docs/api-docs.md`
However, using this has introduced conflicts with existing dependencies in the project.