### PR TITLE
bugfix: cache updates from events all use atomic locks and the calculation of allocated use rbi.DispatchStatus != api.Suspended.

### DIFF
--- a/pkg/dispatcher/cache/cache.go
+++ b/pkg/dispatcher/cache/cache.go
@@ -168,7 +168,7 @@ func NewDispatcherCache(option *DispatcherCacheOption) DispatcherCacheInterface 
 	})
 	sc.clusterInformer = sc.karmadaInformerFactor.Cluster().V1alpha1().Clusters()
 	sc.clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    sc.addRCluster,
+		AddFunc:    sc.addCluster,
 		UpdateFunc: sc.updateCluster,
 		DeleteFunc: sc.deleteCluster,
 	})

--- a/pkg/dispatcher/plugins/capacity/capacity.go
+++ b/pkg/dispatcher/plugins/capacity/capacity.go
@@ -122,7 +122,7 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 			}
 			cp.queueOpts[queue.UID] = attr
 		}
-		if rbi.DispatchStatus == api.UnSuspended {
+		if rbi.DispatchStatus != api.Suspended {
 			resRes := volcanoapi.NewResource(rbi.ResourceBinding.Spec.ReplicaRequirements.ResourceRequest).Multi(float64(rbi.ResourceBinding.Spec.Replicas))
 			attr.allocated = attr.allocated.Add(resRes)
 		}


### PR DESCRIPTION
bugfix: cache updates from events all use atomic locks and the calculation of allocated use rbi.DispatchStatus != api.Suspended.