### PR TITLE
fix: docs example is broken

### DIFF
--- a/docs/deploy/volcano-global-controller-manager.yaml
+++ b/docs/deploy/volcano-global-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
             - --dispatch-period=1s
             - -v=5
             - 2>&1
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: webhook-config
               mountPath: /etc/kubeconfig

--- a/docs/deploy/volcano-global-webhook-manager.yaml
+++ b/docs/deploy/volcano-global-webhook-manager.yaml
@@ -32,7 +32,7 @@ spec:
             - -v=5
             - 2>&1
           image: volcanosh/volcano-global-webhook-manager:latest
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /admission.local.config/certificates
               name: admission-certs
@@ -79,7 +79,7 @@ spec:
       containers:
         - name: main
           image: volcanosh/volcano-global-webhook-manager:latest
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           command: ["./gen-admission-secret.sh", "--service", "volcano-global-webhook", "--namespace",
                     "volcano-global", "--secret", "volcano-global-webhook-cert"]
 ---


### PR DESCRIPTION
When following [volcano-global docs](https://github.com/volcano-sh/volcano-global/blob/main/docs/deploy/README.md) had to add these changes to the example to make it work.