### PR TITLE
bugfix: capacity use karmada dispatching field

### DIFF
--- a/docs/deploy/volcano-global-webhooks.yaml
+++ b/docs/deploy/volcano-global-webhooks.yaml
@@ -12,10 +12,10 @@ webhooks:
     matchPolicy: Equivalent
     reinvocationPolicy: Never
     rules:
-      - operations: ["CREATE"]
-        apiGroups: ["work.karmada.io"]
-        apiVersions: ["v1alpha2"]
-        resources: ["resourcebindings"]
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: [ "work.karmada.io" ]
+        apiVersions: [ "v1alpha2" ]
+        resources: [ "resourcebindings" ]
         scope: "Namespaced"
     sideEffects: None
     timeoutSeconds: 3

--- a/pkg/dispatcher/api/types.go
+++ b/pkg/dispatcher/api/types.go
@@ -17,7 +17,19 @@ limitations under the License.
 package api
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	volcanoapi "volcano.sh/volcano/pkg/scheduler/api"
 )
 
+const (
+	// LastDispatchedContentAnnotationKey is last dispatched content key in annotations of ResourceBinding, value is DispatchContent.
+	LastDispatchedContentAnnotationKey = "volcano-global.volcano.sh/last-dispatched-content"
+)
+
 type AllocatableFn func(qi *volcanoapi.QueueInfo, rbi *ResourceBindingInfo) bool
+
+// DispatchContent includes Replicas and ResourceRequest of the ResourceBinding, it needs to be set in ResourceBinding annotation.
+type DispatchContent struct {
+	Replicas        int32               `json:"replicas"`
+	ResourceRequest corev1.ResourceList `json:"resourceRequest"`
+}


### PR DESCRIPTION
## bug: 
when update workload resource(turn it up) or the value of the resourceBinding replicaDivisionPreference field changes from Divided to Duplicated, volcano-global will be unable to limit the phenomenon of resources.

## fix ideas:
+ webhook-manager: when create or update resourcebinding, check last-dispatched-content anno like: {"replicas":2,"resourceRequest":{"cpu":"1","memory":"1Gi"}}, if current dispatched-content not equal, set `spec.suspension.suspension.dispatching=true`
+ controller-manager: check whether can allocate, set `spec.suspension.suspension.dispatching=false`