### PR TITLE
add helm for volcano-global installation

### DIFF
--- a/installer/helm/chart/volcano-global/Chart.yaml
+++ b/installer/helm/chart/volcano-global/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: volcano-global
+description: A Helm chart for deploying Volcano-global
+version: "1.0.0"
+appVersion: "1.0.0"
+home: https://github.com/volcano-sh/volcano-global
+icon: https://raw.githubusercontent.com/volcano-sh/charts/master/docs/images/volcano-logo.png
+sources:
+  - https://github.com/volcano-sh/volcano-global
+maintainers:
+  - name: volcano-global-maintainers
+    email: volcano-global@volcano.sh

--- a/installer/helm/chart/volcano-global/templates/NOTES.txt
+++ b/installer/helm/chart/volcano-global/templates/NOTES.txt
@@ -1,0 +1,33 @@
+Thank you for installing {{ .Chart.Name }}!
+
+=== Deployment Status ===
+{{- if .Values.controllerManager.enabled }}
+✓ Controller Manager: Enabled (controllers: {{ .Values.controllerManager.controllers }})
+{{- end }}
+{{- if .Values.webhookManager.enabled }}
+✓ Webhook Manager: Enabled
+{{- if .Values.webhookManager.admissionInit.enabled }}
+  → Admission init job will generate TLS certificates
+{{- end }}
+{{- end }}
+
+=== Post-Installation Steps ===
+Apply these resources to karmada-apiserver (not karmada-host):
+
+  # Apply webhooks
+  helm template {{ .Release.Name }} ./installer/helm/chart/volcano-global \
+    --show-only templates/webhooks.yaml | kubectl --context karmada-apiserver apply -f -
+
+  # Apply resource interpreters
+  helm template {{ .Release.Name }} ./installer/helm/chart/volcano-global \
+    --show-only templates/resource-interpreters.yaml | kubectl --context karmada-apiserver apply -f -
+
+  # Apply propagation policy
+  helm template {{ .Release.Name }} ./installer/helm/chart/volcano-global \
+    --show-only templates/propagation-policy.yaml | kubectl --context karmada-apiserver apply -f -
+
+=== Verify Installation ===
+  kubectl get pods -n {{ include "volcano-global.namespace" . }} --context karmada-host
+  kubectl get deployments -n {{ include "volcano-global.namespace" . }} --context karmada-host
+
+For more information: https://github.com/volcano-sh/volcano-global

--- a/installer/helm/chart/volcano-global/templates/_helpers.tpl
+++ b/installer/helm/chart/volcano-global/templates/_helpers.tpl
@@ -1,0 +1,132 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "volcano-global.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "volcano-global.labels" -}}
+helm.sh/chart: {{ include "volcano-global.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Controller Manager labels
+*/}}
+{{- define "volcano-global.controllerManager.labels" -}}
+{{ include "volcano-global.labels" . }}
+app.kubernetes.io/component: controller-manager
+{{- end }}
+
+{{/*
+Controller Manager selector labels
+*/}}
+{{- define "volcano-global.controllerManager.selectorLabels" -}}
+app: volcano-global-controller-manager
+{{- end }}
+
+{{/*
+Webhook Manager labels
+*/}}
+{{- define "volcano-global.webhookManager.labels" -}}
+{{ include "volcano-global.labels" . }}
+app.kubernetes.io/component: webhook-manager
+{{- end }}
+
+{{/*
+Webhook Manager selector labels
+*/}}
+{{- define "volcano-global.webhookManager.selectorLabels" -}}
+app: volcano-global-webhook-manager
+{{- end }}
+
+{{/*
+Admission Init labels
+*/}}
+{{- define "volcano-global.admissionInit.labels" -}}
+{{ include "volcano-global.labels" . }}
+app.kubernetes.io/component: admission-init
+{{- end }}
+
+{{/*
+Create the namespace
+*/}}
+{{- define "volcano-global.namespace" -}}
+{{- default "volcano-global" .Values.namespace.name }}
+{{- end }}
+
+{{/*
+Create the image name for controller manager
+*/}}
+{{- define "volcano-global.controllerManager.image" -}}
+{{- $registry := .Values.image.registry }}
+{{- $repository := .Values.controllerManager.imageName }}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- end }}
+
+{{/*
+Create the image name for webhook manager
+*/}}
+{{- define "volcano-global.webhookManager.image" -}}
+{{- $registry := .Values.image.registry }}
+{{- $repository := .Values.webhookManager.imageName }}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- end }}
+
+{{/*
+Build controller manager arguments
+*/}}
+{{- define "volcano-global.controllerManager.args" -}}
+- --kubeconfig={{ .Values.karmada.kubeconfigMountPath }}/{{ .Values.karmada.kubeconfigSecretKey }}
+- --leader-elect={{ .Values.controllerManager.leaderElect }}
+- --leader-elect-resource-namespace={{ .Values.controllerManager.leaderElectResourceNamespace }}
+- --logtostderr
+{{- if .Values.controllerManager.healthz.enabled }}
+- --enable-healthz=true
+- --healthz-address=$(MY_POD_IP):{{ .Values.controllerManager.healthz.port }}
+{{- end }}
+- --listen-address=$(MY_POD_IP):{{ .Values.controllerManager.metrics.port }}
+- --dispatch-period={{ .Values.controllerManager.dispatchPeriod }}
+- --controllers={{ .Values.controllerManager.controllers }}
+{{- if .Values.controllerManager.reconcilers }}
+- --reconcilers={{ .Values.controllerManager.reconcilers }}
+{{- end }}
+{{- range $key, $value := .Values.controllerManager.featureGates }}
+- --feature-gates={{ $key }}={{ $value }}
+{{- end }}
+- -v={{ .Values.controllerManager.logLevel }}
+- 2>&1
+{{- end }}
+
+{{/*
+Build webhook manager arguments
+*/}}
+{{- define "volcano-global.webhookManager.args" -}}
+- --kubeconfig={{ .Values.karmada.kubeconfigMountPath }}/{{ .Values.karmada.kubeconfigSecretKey }}
+- --enabled-admission={{ .Values.webhookManager.enabledAdmissions }}
+- --tls-cert-file=/admission.local.config/certificates/tls.crt
+- --tls-private-key-file=/admission.local.config/certificates/tls.key
+- --ca-cert-file=/admission.local.config/certificates/ca.crt
+- --webhook-service-name={{ .Values.webhookManager.serviceName }}
+- --webhook-namespace={{ include "volcano-global.namespace" . }}
+- --logtostderr
+{{- if .Values.webhookManager.healthz.enabled }}
+- --enable-healthz=true
+- --healthz-address=$(MY_POD_IP):{{ .Values.webhookManager.healthz.port }}
+{{- end }}
+- --listen-address=$(MY_POD_IP)
+- --port={{ .Values.webhookManager.port }}
+- -v={{ .Values.webhookManager.logLevel }}
+- 2>&1
+{{- end }}

--- a/installer/helm/chart/volcano-global/templates/_helpers.tpl
+++ b/installer/helm/chart/volcano-global/templates/_helpers.tpl
@@ -106,7 +106,6 @@ Build controller manager arguments
 - --feature-gates={{ $key }}={{ $value }}
 {{- end }}
 - -v={{ .Values.controllerManager.logLevel }}
-- 2>&1
 {{- end }}
 
 {{/*
@@ -128,5 +127,4 @@ Build webhook manager arguments
 - --listen-address=$(MY_POD_IP)
 - --port={{ .Values.webhookManager.port }}
 - -v={{ .Values.webhookManager.logLevel }}
-- 2>&1
 {{- end }}

--- a/installer/helm/chart/volcano-global/templates/configmap.yaml
+++ b/installer/helm/chart/volcano-global/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.datasourcePlugins.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volcano-global-datasource-plugins
+  namespace: {{ include "volcano-global.namespace" . }}
+  labels:
+    {{- include "volcano-global.labels" . | nindent 4 }}
+data:
+  {{- range $name, $config := .Values.datasourcePlugins.plugins }}
+  {{ $name }}: |
+    {{ $config | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/installer/helm/chart/volcano-global/templates/controller-manager.yaml
+++ b/installer/helm/chart/volcano-global/templates/controller-manager.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.controllerManager.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: volcano-global-controller-manager
+  namespace: {{ include "volcano-global.namespace" . }}
+  labels:
+    {{- include "volcano-global.controllerManager.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controllerManager.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "volcano-global.controllerManager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "volcano-global.controllerManager.selectorLabels" . | nindent 8 }}
+      {{- with .Values.controllerManager.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: volcano-global-controller-manager
+          image: {{ include "volcano-global.controllerManager.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.controllerManager.securityContext | default .Values.defaultSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            {{- include "volcano-global.controllerManager.args" . | nindent 12 }}
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          {{- if .Values.controllerManager.healthz.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.controllerManager.healthz.port }}
+              scheme: HTTP
+            failureThreshold: {{ .Values.controllerManager.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.controllerManager.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controllerManager.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.controllerManager.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.controllerManager.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.controllerManager.healthz.port }}
+              scheme: HTTP
+            failureThreshold: {{ .Values.controllerManager.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.controllerManager.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controllerManager.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.controllerManager.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.controllerManager.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- with .Values.controllerManager.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: webhook-config
+              mountPath: {{ .Values.karmada.kubeconfigMountPath }}
+              readOnly: true
+      volumes:
+        - name: webhook-config
+          secret:
+            secretName: {{ .Values.karmada.kubeconfigSecretName }}
+{{- end }}

--- a/installer/helm/chart/volcano-global/templates/namespace.yaml
+++ b/installer/helm/chart/volcano-global/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "volcano-global.namespace" . }}
+  labels:
+    {{- include "volcano-global.labels" . | nindent 4 }}
+{{- end }}

--- a/installer/helm/chart/volcano-global/templates/propagation-policy.yaml
+++ b/installer/helm/chart/volcano-global/templates/propagation-policy.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.propagationPolicies.enabled }}
+{{- if .Values.propagationPolicies.allQueue.enabled }}
+apiVersion: policy.karmada.io/v1alpha1
+kind: ClusterPropagationPolicy
+metadata:
+  name: volcano-global-all-queue-propagation
+  labels:
+    {{- include "volcano-global.labels" . | nindent 4 }}
+    {{- if .Values.propagationPolicies.allQueue.deletionProtected }}
+    resourcetemplate.karmada.io/deletion-protected: Always
+    {{- end }}
+spec:
+  resourceSelectors:
+    - apiVersion: scheduling.volcano.sh/v1beta1
+      kind: Queue
+  placement:
+    replicaScheduling:
+      replicaSchedulingType: Duplicated
+{{- end }}
+{{- end }}

--- a/installer/helm/chart/volcano-global/templates/resource-interpreters.yaml
+++ b/installer/helm/chart/volcano-global/templates/resource-interpreters.yaml
@@ -40,7 +40,7 @@ spec:
           if observedObj == nil or observedObj.status == nil then
             return false
           end
-          return observedObj.status.phase == Running
+          return observedObj.status.phase == "Running"
         end
     statusReflection:
       luaScript: >
@@ -197,24 +197,30 @@ spec:
           local states = {}
           for i = 1, #statusItems do
             local status = statusItems[i].status
-            if status ~= nil and status.allocated ~= nil then
-              for key, value in pairs(status.allocated) do
-                if aggregatedStatus.allocated[key] == nil then
-                  aggregatedStatus.allocated[key] = value
-                else
-                  if key == "cpu" then
-                    local currentCpu = parseCpu(aggregatedStatus.allocated[key])
-                    local newCpu = parseCpu(value)
-                    aggregatedStatus.allocated[key] = formatCpu(currentCpu + newCpu)
-                  elseif key == "memory" then
-                    local currentMemory = parseMemory(aggregatedStatus.allocated[key])
-                    local newMemory = parseMemory(value)
-                    aggregatedStatus.allocated[key] = formatMemory(currentMemory + newMemory)
-                  elseif isNumericField(value) then  
-                    local currentValue = tonumber(aggregatedStatus.allocated[key])
-                    local newValue = tonumber(value)
-                    if currentValue ~= nil and newValue ~= nil then
-                      aggregatedStatus.allocated[key] = tostring(currentValue + newValue)
+            if status ~= nil then
+              if status.state ~= nil then
+                table.insert(states, status.state)
+              end
+
+              if status.allocated ~= nil then
+                for key, value in pairs(status.allocated) do
+                  if aggregatedStatus.allocated[key] == nil then
+                    aggregatedStatus.allocated[key] = value
+                  else
+                    if key == "cpu" then
+                      local currentCpu = parseCpu(aggregatedStatus.allocated[key])
+                      local newCpu = parseCpu(value)
+                      aggregatedStatus.allocated[key] = formatCpu(currentCpu + newCpu)
+                    elseif key == "memory" then
+                      local currentMemory = parseMemory(aggregatedStatus.allocated[key])
+                      local newMemory = parseMemory(value)
+                      aggregatedStatus.allocated[key] = formatMemory(currentMemory + newMemory)
+                    elseif isNumericField(value) then  
+                      local currentValue = tonumber(aggregatedStatus.allocated[key])
+                      local newValue = tonumber(value)
+                      if currentValue ~= nil and newValue ~= nil then
+                        aggregatedStatus.allocated[key] = tostring(currentValue + newValue)
+                      end
                     end
                   end
                 end

--- a/installer/helm/chart/volcano-global/templates/resource-interpreters.yaml
+++ b/installer/helm/chart/volcano-global/templates/resource-interpreters.yaml
@@ -1,0 +1,234 @@
+{{- if .Values.resourceInterpreters.enabled }}
+{{- if .Values.resourceInterpreters.vcjob.enabled }}
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: vcjob-configuration
+  labels:
+    {{- include "volcano-global.labels" . | nindent 4 }}
+spec:
+  target:
+    apiVersion: batch.volcano.sh/v1alpha1
+    kind: Job
+  customizations:
+    replicaResource:
+      luaScript: >
+        local kube = require("kube")
+        function GetReplicas(obj)
+          replica = obj.spec.tasks[1].replicas
+          requirement = kube.accuratePodRequirements(obj.spec.tasks[1].template)
+          return replica, requirement
+        end
+    replicaRevision:
+      luaScript: >
+        function ReviseReplica(obj, desiredReplica)
+          obj.spec.tasks[1].replicas = desiredReplica
+          return obj
+        end
+    retention:
+      luaScript: >
+        function Retain(desiredObj, observedObj)
+          for i = 1, #observedObj.spec.tasks do
+            desiredObj.spec.tasks[i].maxRetry = observedObj.spec.tasks[i].maxRetry
+            desiredObj.spec.tasks[i].minAvailable = observedObj.spec.tasks[i].minAvailable
+          end
+          return desiredObj
+        end
+    healthInterpretation:
+      luaScript: >
+        function InterpretHealth(observedObj)
+          if observedObj == nil or observedObj.status == nil then
+            return false
+          end
+          return observedObj.status.phase == Running
+        end
+    statusReflection:
+      luaScript: >
+        function ReflectStatus (observedObj)
+          status = {}
+          if observedObj == nil or observedObj.status == nil then
+            return status
+          end
+          status.minAvailable = observedObj.status.minAvailable
+          status.running = observedObj.status.running
+          status.taskStatusCount = observedObj.status.taskStatusCount
+          status.state = observedObj.status.state
+          return status
+        end
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil then
+            return desiredObj
+          end
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          running = 0
+          minAvailable = 0
+          taskStatusCount = {}
+          state = {}
+          for i = 1, #statusItems do
+            if statusItems[i].status ~= nil and statusItems[i].status.running ~= nil then
+              running = running + statusItems[i].status.running
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.minAvailable ~= nil then
+              minAvailable = statusItems[i].status.minAvailable
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.state ~= nil then
+              state = statusItems[i].status.state
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.taskStatusCount ~= nil then
+              for key, value in pairs(statusItems[i].status.taskStatusCount) do
+                if taskStatusCount[key] == nil then
+                   taskStatusCount[key] = { phase = {} }
+                end
+                for k,v in pairs(value.phase) do
+                  if taskStatusCount[key].phase[k] == nil then
+                    taskStatusCount[key].phase[k] = 0
+                  end    
+                  taskStatusCount[key].phase[k] =  taskStatusCount[key].phase[k] + v
+                end
+              end
+            end
+          end
+          desiredObj.status.running = running
+          desiredObj.status.minAvailable = minAvailable
+          desiredObj.status.state = state
+          desiredObj.status.taskStatusCount = taskStatusCount
+          return desiredObj
+        end
+{{- end }}
+---
+{{- if .Values.resourceInterpreters.queue.enabled }}
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: queue-configuration
+  labels:
+    {{- include "volcano-global.labels" . | nindent 4 }}
+spec:
+  target:
+    apiVersion: scheduling.volcano.sh/v1beta1
+    kind: Queue
+  customizations:
+    statusReflection:
+      luaScript: >
+        function ReflectStatus (observedObj)
+          return observedObj.status
+        end
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil then
+            return desiredObj
+          end
+
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+
+          local aggregatedStatus = {
+            allocated = {},
+            reservation = {},
+            running = 0,
+            state = ""
+          }
+
+          local function parseCpu(cpuStr)
+            if string.find(cpuStr, "m") then
+              return tonumber(string.match(cpuStr, "%d+")) / 1000
+            else
+              return tonumber(cpuStr)
+            end
+          end
+
+          local function formatCpu(cpuNum)
+            if cpuNum == math.floor(cpuNum) then
+              return tostring(cpuNum)
+            else
+              return tostring(cpuNum * 1000) .. "m"
+            end
+          end
+
+          local function parseMemory(memoryStr)
+            if string.find(memoryStr, "Gi") then
+              return tonumber(string.match(memoryStr, "%d+")) * 1024
+            elseif string.find(memoryStr, "G") then
+              return tonumber(string.match(memoryStr, "%d+")) * 1000
+            elseif string.find(memoryStr, "Mi") or string.find(memoryStr, "M") then
+              return tonumber(string.match(memoryStr, "%d+"))
+            elseif string.find(memoryStr, "Ki") then
+              return tonumber(string.match(memoryStr, "%d+")) / 1024
+            else
+              return tonumber(memoryStr) / (1024 * 1024)
+            end
+          end
+
+          local function formatMemory(memoryNum)
+            if memoryNum >= 1024 then
+              return tostring(memoryNum / 1024) .. "Gi"
+            else
+              return tostring(memoryNum) .. "Mi"
+            end
+          end
+
+          local function isNumericField(value)
+            if type(value) == "number" then
+              return true
+            elseif type(value) == "string" then
+              return tonumber(value) ~= nil
+            end
+            return false
+          end
+
+          local function aggregateState(states)
+            local result = "Open"
+  
+            for _, state in ipairs(states) do
+              if state == "Closed" then
+                result = "Closed"
+                break
+              end
+            end
+            return result
+          end
+        
+          local states = {}
+          for i = 1, #statusItems do
+            local status = statusItems[i].status
+            if status ~= nil and status.allocated ~= nil then
+              for key, value in pairs(status.allocated) do
+                if aggregatedStatus.allocated[key] == nil then
+                  aggregatedStatus.allocated[key] = value
+                else
+                  if key == "cpu" then
+                    local currentCpu = parseCpu(aggregatedStatus.allocated[key])
+                    local newCpu = parseCpu(value)
+                    aggregatedStatus.allocated[key] = formatCpu(currentCpu + newCpu)
+                  elseif key == "memory" then
+                    local currentMemory = parseMemory(aggregatedStatus.allocated[key])
+                    local newMemory = parseMemory(value)
+                    aggregatedStatus.allocated[key] = formatMemory(currentMemory + newMemory)
+                  elseif isNumericField(value) then  
+                    local currentValue = tonumber(aggregatedStatus.allocated[key])
+                    local newValue = tonumber(value)
+                    if currentValue ~= nil and newValue ~= nil then
+                      aggregatedStatus.allocated[key] = tostring(currentValue + newValue)
+                    end
+                  end
+                end
+              end
+
+              if status.running ~= nil then
+                aggregatedStatus.running = aggregatedStatus.running + status.running
+              end
+            end
+          end
+
+          aggregatedStatus.state = aggregateState(states)
+          desiredObj.status = aggregatedStatus
+          return desiredObj
+        end
+{{- end }}
+{{- end }}

--- a/installer/helm/chart/volcano-global/templates/webhook-manager.yaml
+++ b/installer/helm/chart/volcano-global/templates/webhook-manager.yaml
@@ -1,0 +1,227 @@
+{{- if .Values.webhookManager.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: volcano-global-webhook-manager
+  namespace: {{ include "volcano-global.namespace" . }}
+  labels:
+    {{- include "volcano-global.webhookManager.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.webhookManager.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "volcano-global.webhookManager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "volcano-global.webhookManager.selectorLabels" . | nindent 8 }}
+      {{- with .Values.webhookManager.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhookManager.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhookManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhookManager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhookManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: volcano-global-webhook-manager
+          image: {{ include "volcano-global.webhookManager.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.webhookManager.securityContext | default .Values.defaultSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            {{- include "volcano-global.webhookManager.args" . | nindent 12 }}
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          {{- if .Values.webhookManager.healthz.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.webhookManager.healthz.port }}
+              scheme: HTTPS
+            failureThreshold: {{ .Values.webhookManager.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.webhookManager.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webhookManager.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.webhookManager.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.webhookManager.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.webhookManager.healthz.port }}
+              scheme: HTTPS
+            failureThreshold: {{ .Values.webhookManager.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.webhookManager.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webhookManager.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.webhookManager.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.webhookManager.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- with .Values.webhookManager.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: admission-certs
+              mountPath: /admission.local.config/certificates
+              readOnly: true
+            - name: webhook-config
+              mountPath: {{ .Values.karmada.kubeconfigMountPath }}
+              readOnly: true
+      volumes:
+        - name: webhook-config
+          secret:
+            secretName: {{ .Values.karmada.kubeconfigSecretName }}
+        - name: admission-certs
+          secret:
+            secretName: volcano-global-webhook-cert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.webhookManager.serviceName }}
+  namespace: {{ include "volcano-global.namespace" . }}
+  labels:
+    {{- include "volcano-global.webhookManager.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: {{ .Values.webhookManager.port }}
+  selector:
+    {{- include "volcano-global.webhookManager.selectorLabels" . | nindent 4 }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+{{- if and .Values.webhookManager.enabled .Values.webhookManager.admissionInit.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: volcano-global-webhook-init-sa
+  namespace: {{ include "volcano-global.namespace" . }}
+  labels:
+    {{- include "volcano-global.admissionInit.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: volcano-global-webhook-init-clusterrole
+  labels:
+    {{- include "volcano-global.admissionInit.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: volcano-global-webhook-init-clusterrolebinding
+  labels:
+    {{- include "volcano-global.admissionInit.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: volcano-global-webhook-init-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: volcano-global-webhook-init-sa
+    namespace: {{ include "volcano-global.namespace" . }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: volcano-global-admission-init
+  namespace: {{ include "volcano-global.namespace" . }}
+  labels:
+    {{- include "volcano-global.admissionInit.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "5"
+spec:
+  backoffLimit: {{ .Values.webhookManager.admissionInit.backoffLimit }}
+  template:
+    spec:
+      serviceAccountName: volcano-global-webhook-init-sa
+      restartPolicy: Never
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhookManager.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhookManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhookManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhookManager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: main
+          image: {{ include "volcano-global.webhookManager.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - ./gen-admission-secret.sh
+            - --service
+            - {{ .Values.webhookManager.serviceName }}
+            - --namespace
+            - {{ include "volcano-global.namespace" . }}
+            - --secret
+            - volcano-global-webhook-cert
+          {{- with .Values.webhookManager.securityContext | default .Values.defaultSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.webhookManager.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/installer/helm/chart/volcano-global/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano-global/templates/webhooks.yaml
@@ -11,7 +11,15 @@ webhooks:
     admissionReviewVersions:
       - v1
     clientConfig:
-      url: https://{{ .Values.webhookManager.serviceName }}.{{ include "volcano-global.namespace" . }}.svc:443/resourcebindings/mutate
+      service:
+        name: {{ .Values.webhookManager.serviceName }}
+        namespace: {{ include "volcano-global.namespace" . }}
+        path: /resourcebindings/mutate
+        port: 443
+      {{- $secret := lookup "v1" "Secret" (include "volcano-global.namespace" .) .Values.webhookManager.certSecretName }}
+      {{- if $secret }}
+      caBundle: {{ index $secret.data "ca.crt" }}
+      {{- end }}
     failurePolicy: {{ .Values.webhooks.resourceBindingsMutate.failurePolicy }}
     matchPolicy: Equivalent
     reinvocationPolicy: Never
@@ -37,7 +45,15 @@ webhooks:
     admissionReviewVersions:
       - v1
     clientConfig:
-      url: https://{{ .Values.webhookManager.serviceName }}.{{ include "volcano-global.namespace" . }}.svc:443/jobs/mutate
+      service:
+        name: {{ .Values.webhookManager.serviceName }}
+        namespace: {{ include "volcano-global.namespace" . }}
+        path: /jobs/mutate
+        port: 443
+      {{- $secret := lookup "v1" "Secret" (include "volcano-global.namespace" .) .Values.webhookManager.certSecretName }}
+      {{- if $secret }}
+      caBundle: {{ index $secret.data "ca.crt" }}
+      {{- end }}
     failurePolicy: {{ .Values.webhooks.jobsMutate.failurePolicy }}
     matchPolicy: Equivalent
     reinvocationPolicy: Never
@@ -63,7 +79,15 @@ webhooks:
     admissionReviewVersions:
       - v1
     clientConfig:
-      url: https://{{ .Values.webhookManager.serviceName }}.{{ include "volcano-global.namespace" . }}.svc:443/jobs/validate
+      service:
+        name: {{ .Values.webhookManager.serviceName }}
+        namespace: {{ include "volcano-global.namespace" . }}
+        path: /jobs/validate
+        port: 443
+      {{- $secret := lookup "v1" "Secret" (include "volcano-global.namespace" .) .Values.webhookManager.certSecretName }}
+      {{- if $secret }}
+      caBundle: {{ index $secret.data "ca.crt" }}
+      {{- end }}
     failurePolicy: {{ .Values.webhooks.jobsValidate.failurePolicy }}
     matchPolicy: Equivalent
     rules:

--- a/installer/helm/chart/volcano-global/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano-global/templates/webhooks.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.webhooks.enabled }}
+{{- if .Values.webhooks.resourceBindingsMutate.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: volcano-admission-service-resourcebindings-mutate
+  labels:
+    {{- include "volcano-global.labels" . | nindent 4 }}
+webhooks:
+  - name: mutateresourcebindings.volcano.sh
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      url: https://{{ .Values.webhookManager.serviceName }}.{{ include "volcano-global.namespace" . }}.svc:443/resourcebindings/mutate
+    failurePolicy: {{ .Values.webhooks.resourceBindingsMutate.failurePolicy }}
+    matchPolicy: Equivalent
+    reinvocationPolicy: Never
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["work.karmada.io"]
+        apiVersions: ["v1alpha2"]
+        resources: ["resourcebindings"]
+        scope: "Namespaced"
+    sideEffects: None
+    timeoutSeconds: {{ .Values.webhooks.resourceBindingsMutate.timeoutSeconds }}
+{{- end }}
+---
+{{- if .Values.webhooks.jobsMutate.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: volcano-admission-service-jobs-mutate
+  labels:
+    {{- include "volcano-global.labels" . | nindent 4 }}
+webhooks:
+  - name: mutatejob.volcano.sh
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      url: https://{{ .Values.webhookManager.serviceName }}.{{ include "volcano-global.namespace" . }}.svc:443/jobs/mutate
+    failurePolicy: {{ .Values.webhooks.jobsMutate.failurePolicy }}
+    matchPolicy: Equivalent
+    reinvocationPolicy: Never
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["batch.volcano.sh"]
+        apiVersions: ["v1alpha1"]
+        resources: ["jobs"]
+        scope: "Namespaced"
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: {{ .Values.webhooks.jobsMutate.timeoutSeconds }}
+{{- end }}
+---
+{{- if .Values.webhooks.jobsValidate.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: volcano-admission-service-jobs-validate
+  labels:
+    {{- include "volcano-global.labels" . | nindent 4 }}
+webhooks:
+  - name: validatejob.volcano.sh
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      url: https://{{ .Values.webhookManager.serviceName }}.{{ include "volcano-global.namespace" . }}.svc:443/jobs/validate
+    failurePolicy: {{ .Values.webhooks.jobsValidate.failurePolicy }}
+    matchPolicy: Equivalent
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["batch.volcano.sh"]
+        apiVersions: ["v1alpha1"]
+        resources: ["jobs"]
+        scope: "Namespaced"
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: {{ .Values.webhooks.jobsValidate.timeoutSeconds }}
+{{- end }}
+{{- end }}

--- a/installer/helm/chart/volcano-global/values.yaml
+++ b/installer/helm/chart/volcano-global/values.yaml
@@ -1,0 +1,285 @@
+# -- Namespace configuration
+namespace:
+  # -- Name of the namespace where volcano-global will be deployed
+  name: volcano-global
+  # -- Create the namespace (set to false if it already exists)
+  create: true
+
+# -- Global image configuration
+image:
+  # -- Image registry
+  registry: volcanosh
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Image tag (defaults to Chart appVersion)
+  tag: ""
+  # -- Image pull secrets
+  pullSecrets: []
+
+# -- Controller Manager configuration
+controllerManager:
+  # -- Enable controller manager deployment
+  enabled: true
+  # -- Controller manager replica count
+  replicaCount: 1
+  # -- Controller manager image name
+  imageName: volcano-global-controller-manager
+  # -- Container resource requests and limits
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 250m
+    #   memory: 256Mi
+  
+  # -- Controllers to enable (comma-separated)
+  # Options: dispatcher, reconciler
+  controllers: "dispatcher"
+  
+  # -- Reconcilers to enable when reconciler controller is enabled
+  # Options: hyperjob
+  reconcilers: ""
+  
+  # -- Feature gates configuration
+  featureGates: {}
+    # DataDependencyAwareness: true
+  
+  # -- Dispatch period for the dispatcher
+  dispatchPeriod: "1s"
+  
+  # -- Enable leader election
+  leaderElect: false
+  
+  # -- Leader election resource namespace
+  leaderElectResourceNamespace: volcano-global
+  
+  # -- Logging verbosity level
+  logLevel: 5
+  
+  # -- Health check configuration
+  healthz:
+    enabled: true
+    port: 11251
+  
+  # -- Metrics configuration
+  metrics:
+    port: 9090
+  
+  # -- Liveness probe configuration
+  livenessProbe:
+    failureThreshold: 5
+    initialDelaySeconds: 60
+    periodSeconds: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+  
+  # -- Readiness probe configuration
+  readinessProbe:
+    failureThreshold: 5
+    initialDelaySeconds: 3
+    periodSeconds: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+  
+  # -- Node selector for pod assignment
+  nodeSelector: {}
+  
+  # -- Tolerations for pod assignment
+  tolerations: []
+  
+  # -- Affinity for pod assignment
+  affinity: {}
+  
+  # -- Pod annotations
+  podAnnotations: {}
+  
+  # -- Pod security context
+  podSecurityContext: {}
+  
+  # -- Container security context
+  securityContext: {}
+
+# -- Webhook Manager configuration
+webhookManager:
+  # -- Enable webhook manager deployment
+  enabled: true
+  # -- Webhook manager replica count
+  replicaCount: 1
+  # -- Webhook manager image name
+  imageName: volcano-global-webhook-manager
+  # -- Container resource requests and limits
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 250m
+    #   memory: 256Mi
+  
+  # -- Enabled admission webhooks
+  enabledAdmissions: "/resourcebindings/mutate,/jobs/mutate,/jobs/validate"
+  
+  # -- Webhook service name
+  serviceName: volcano-global-webhook
+  
+  # -- Webhook server port
+  port: 8443
+  
+  # -- Logging verbosity level
+  logLevel: 5
+  
+  # -- Health check configuration
+  healthz:
+    enabled: true
+    port: 11251
+  
+  # -- Liveness probe configuration
+  livenessProbe:
+    failureThreshold: 5
+    initialDelaySeconds: 60
+    periodSeconds: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+  
+  # -- Readiness probe configuration
+  readinessProbe:
+    failureThreshold: 5
+    initialDelaySeconds: 3
+    periodSeconds: 3
+    successThreshold: 1
+    timeoutSeconds: 5
+  
+  # -- Admission init job configuration
+  admissionInit:
+    # -- Enable admission init job
+    enabled: true
+    # -- Backoff limit for the job
+    backoffLimit: 3
+  
+  # -- Node selector for pod assignment
+  nodeSelector: {}
+  
+  # -- Tolerations for pod assignment
+  tolerations: []
+  
+  # -- Affinity for pod assignment
+  affinity: {}
+  
+  # -- Pod annotations
+  podAnnotations: {}
+  
+  # -- Pod security context
+  podSecurityContext: {}
+  
+  # -- Container security context
+  securityContext: {}
+
+# -- Webhook configurations
+webhooks:
+  # -- Enable webhook configurations
+  enabled: true
+  
+  # -- Mutating webhook for ResourceBindings
+  resourceBindingsMutate:
+    enabled: true
+    failurePolicy: Fail
+    timeoutSeconds: 3
+  
+  # -- Mutating webhook for Jobs
+  jobsMutate:
+    enabled: true
+    failurePolicy: Fail
+    timeoutSeconds: 10
+  
+  # -- Validating webhook for Jobs
+  jobsValidate:
+    enabled: true
+    failurePolicy: Fail
+    timeoutSeconds: 10
+
+# -- Resource Interpreter Customizations
+resourceInterpreters:
+  # -- Enable resource interpreter customizations
+  enabled: true
+  
+  # -- VCJob (Volcano Job) resource interpreter
+  vcjob:
+    enabled: true
+  
+  # -- Queue resource interpreter
+  queue:
+    enabled: true
+
+# -- Propagation Policies
+propagationPolicies:
+  # -- Enable propagation policies
+  enabled: true
+  
+  # -- All Queue propagation policy
+  allQueue:
+    # -- Enable all-queue ClusterPropagationPolicy
+    enabled: true
+    # -- Enable deletion protection
+    deletionProtected: true
+
+# -- Karmada configuration
+karmada:
+  # -- Name of the secret containing Karmada kubeconfig
+  kubeconfigSecretName: karmada-webhook-config
+  # -- Key in the secret containing the kubeconfig
+  kubeconfigSecretKey: karmada.config
+  # -- Mount path for the kubeconfig
+  kubeconfigMountPath: /etc/kubeconfig
+
+# -- Datasource plugins ConfigMap (for DataDependency feature)
+datasourcePlugins:
+  # -- Enable datasource plugins ConfigMap
+  enabled: false
+  # -- Plugin configurations (as JSON strings)
+  plugins: {}
+    # amoro: |
+    #   {
+    #     "system": "amoro",
+    #     "endpoint": {
+    #       "url": "http://your-amoro-server.com",
+    #       "port": 1630
+    #     },
+    #     "locationMapping": {
+    #       "s3://your-warehouse-dc1/": ["cluster1", "cluster2"],
+    #       "s3://your-warehouse-dc2/": ["cluster3"]
+    #     },
+    #     "retryConfig": {
+    #       "maxRetries": 3,
+    #       "initialBackoff": "1s",
+    #       "maxBackoff": "30s",
+    #       "backoffMultiplier": 2.0,
+    #       "timeout": "30s"
+    #     }
+    #   }
+
+# -- Service account configuration
+serviceAccount:
+  # -- Annotations to add to the service account
+  annotations: {}
+
+# -- Common labels to add to all resources
+commonLabels: {}
+
+# -- Service configuration for webhook
+service:
+  # -- IP family policy (SingleStack, PreferDualStack, RequireDualStack)
+  ipFamilyPolicy: ""
+  # -- IP families (IPv4, IPv6)
+  ipFamilies: []
+
+# -- Default security context for all containers
+defaultSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault

--- a/installer/helm/chart/volcano-global/values.yaml
+++ b/installer/helm/chart/volcano-global/values.yaml
@@ -123,6 +123,9 @@ webhookManager:
   # -- Webhook service name
   serviceName: volcano-global-webhook
   
+  # -- Certificate secret name (created by admission-init job)
+  certSecretName: volcano-global-webhook-cert
+  
   # -- Webhook server port
   port: 8443
   


### PR DESCRIPTION
This PR adds helm chart installation for volcano-global as mentioned in  #30
Components Included:
  1. Controller Manager - Deployment with health probes and security context
  2. Webhook Manager - Deployment, Service, RBAC, and admission init Job
  3. Webhooks - MutatingWebhookConfiguration, ValidatingWebhookConfiguration
  4. Resource Interpreters - VCJob and Queue Karmada interpreters
  5. Propagation Policy - ClusterPropagationPolicy for Queue distribution
  6. ConfigMap - Optional datasource plugins configuration 