### PR TITLE
Add cluster validation and scoring helpers to pkg/utils

### DIFF
--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -23,15 +23,31 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func CheckClusterReady(cluster *clusterv1alpha1.Cluster) (bool, string) {
-	for _, condition := range cluster.Status.Conditions {
-		if condition.Type == clusterv1alpha1.ClusterConditionReady {
-			if condition.Status == metav1.ConditionTrue {
-				return true, ""
-			} else {
-				return false, fmt.Sprintf("Cluster <%s> is not ready, reason: %s, message: %s", cluster.Name, condition.Reason, condition.Message)
-			}
+// GetClusterCondition returns the condition with the specified type from cluster status.
+// Returns nil if the condition is not found.
+func GetClusterCondition(cluster *clusterv1alpha1.Cluster, conditionType clusterv1alpha1.ClusterConditionType) *metav1.Condition {
+	for i := range cluster.Status.Conditions {
+		if cluster.Status.Conditions[i].Type == string(conditionType) {
+			return &cluster.Status.Conditions[i]
 		}
 	}
-	return false, fmt.Sprintf("Cluster<%s> has not %s Condition", cluster.Name, clusterv1alpha1.ClusterConditionReady)
+	return nil
+}
+
+// IsClusterReady returns true if the cluster is in Ready condition with status True.
+func IsClusterReady(cluster *clusterv1alpha1.Cluster) bool {
+	condition := GetClusterCondition(cluster, clusterv1alpha1.ClusterConditionReady)
+	return condition != nil && condition.Status == metav1.ConditionTrue
+}
+
+// CheckClusterReady checks if the cluster is ready and returns a detailed message if not.
+func CheckClusterReady(cluster *clusterv1alpha1.Cluster) (bool, string) {
+	condition := GetClusterCondition(cluster, clusterv1alpha1.ClusterConditionReady)
+	if condition == nil {
+		return false, fmt.Sprintf("Cluster<%s> has not %s Condition", cluster.Name, clusterv1alpha1.ClusterConditionReady)
+	}
+	if condition.Status == metav1.ConditionTrue {
+		return true, ""
+	}
+	return false, fmt.Sprintf("Cluster<%s> is not ready, reason: %s, message: %s", cluster.Name, condition.Reason, condition.Message)
 }

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ValidateClusterCapacity checks if a cluster has sufficient capacity for workload.
+// Returns true if cluster can accommodate the workload, and an error message if not.
+func ValidateClusterCapacity(cluster *clusterv1alpha1.Cluster, requiredResources map[string]string) (bool, string) {
+	if cluster == nil {
+		return false, "cluster object is nil"
+	}
+
+	if cluster.Status.Allocatable == nil {
+		return false, fmt.Sprintf("cluster %s has no allocatable resources", cluster.Name)
+	}
+
+	if ready, msg := CheckClusterReady(cluster); !ready {
+		return false, fmt.Sprintf("cluster %s is not ready for scheduling, details: %s", cluster.Name, msg)
+	}
+
+	return true, ""
+}
+
+// IsClusterSchedulable checks if a cluster is schedulable based on taints and conditions.
+// A cluster is schedulable if it has no unschedulable taints and is in Ready condition.
+func IsClusterSchedulable(cluster *clusterv1alpha1.Cluster) bool {
+	if cluster == nil {
+		return false
+	}
+
+	if cluster.Spec.Taints != nil {
+		for _, taint := range cluster.Spec.Taints {
+			if taint.Key == "node.kubernetes.io/unschedulable" {
+				return false
+			}
+		}
+	}
+
+	return IsClusterReady(cluster)
+}
+
+// GetClusterScheduleScore calculates a scheduling score for a cluster based on resource utilization.
+// Higher score = more suitable for scheduling. Range: 0-100.
+func GetClusterScheduleScore(cluster *clusterv1alpha1.Cluster) int {
+	if cluster == nil || !IsClusterSchedulable(cluster) {
+		return 0
+	}
+	score := 100
+	if cluster.Spec.Taints != nil && len(cluster.Spec.Taints) > 0 {
+		score -= len(cluster.Spec.Taints) * 10
+	}
+
+	if score < 0 {
+		score = 0
+	}
+	return score
+}
+
+// GetClusterReadyTime returns the time when cluster became ready.
+// Returns nil if cluster is not ready.
+func GetClusterReadyTime(cluster *clusterv1alpha1.Cluster) *metav1.Time {
+	if cluster == nil {
+		return nil
+	}
+
+	condition := GetClusterCondition(cluster, clusterv1alpha1.ClusterConditionReady)
+	if condition != nil && condition.Status == metav1.ConditionTrue {
+		return &condition.LastTransitionTime
+	}
+	return nil
+}

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -20,7 +20,13 @@ import (
 	"fmt"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// ClusterUnschedulableTaintKey is the taint key that prevents scheduling to a cluster.
+	ClusterUnschedulableTaintKey = "cluster.karmada.io/unschedulable"
 )
 
 // ValidateClusterCapacity checks if a cluster has sufficient capacity for workload.
@@ -32,6 +38,22 @@ func ValidateClusterCapacity(cluster *clusterv1alpha1.Cluster, requiredResources
 
 	if cluster.Status.Allocatable == nil {
 		return false, fmt.Sprintf("cluster %s has no allocatable resources", cluster.Name)
+	}
+
+	// Compare required resources against allocatable
+	for name, reqStr := range requiredResources {
+		reqQty, err := resource.ParseQuantity(reqStr)
+		if err != nil {
+			return false, fmt.Sprintf("invalid required resource %s: %v", reqStr, err)
+		}
+
+		if allocQty, ok := cluster.Status.Allocatable[metav1.ResourceName(name)]; ok {
+			if allocQty.Cmp(reqQty) < 0 {
+				return false, fmt.Sprintf("insufficient %s: required %s, allocatable %s", name, reqStr, allocQty.String())
+			}
+		} else {
+			return false, fmt.Sprintf("resource %s not reported by cluster", name)
+		}
 	}
 
 	if ready, msg := CheckClusterReady(cluster); !ready {
@@ -50,7 +72,7 @@ func IsClusterSchedulable(cluster *clusterv1alpha1.Cluster) bool {
 
 	if cluster.Spec.Taints != nil {
 		for _, taint := range cluster.Spec.Taints {
-			if taint.Key == "node.kubernetes.io/unschedulable" {
+			if taint.Key == ClusterUnschedulableTaintKey {
 				return false
 			}
 		}
@@ -59,7 +81,7 @@ func IsClusterSchedulable(cluster *clusterv1alpha1.Cluster) bool {
 	return IsClusterReady(cluster)
 }
 
-// GetClusterScheduleScore calculates a scheduling score for a cluster based on resource utilization.
+// GetClusterScheduleScore calculates a scheduling score for a cluster based on its characteristics.
 // Higher score = more suitable for scheduling. Range: 0-100.
 func GetClusterScheduleScore(cluster *clusterv1alpha1.Cluster) int {
 	if cluster == nil || !IsClusterSchedulable(cluster) {

--- a/pkg/utils/validation_test.go
+++ b/pkg/utils/validation_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateClusterCapacity(t *testing.T) {
+	tests := []struct {
+		name             string
+		cluster          *clusterv1alpha1.Cluster
+		required         map[string]string
+		expectedValid    bool
+		expectedContains string
+	}{
+		{
+			name:             "nil cluster",
+			cluster:          nil,
+			expectedValid:    false,
+			expectedContains: "nil",
+		},
+		{
+			name: "cluster with no allocatable resources",
+			cluster: &clusterv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+			},
+			expectedValid:    false,
+			expectedContains: "no allocatable resources",
+		},
+		{
+			name: "insufficient cpu",
+			cluster: &clusterv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Status: clusterv1alpha1.ClusterStatus{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("500m"),
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(clusterv1alpha1.ClusterConditionReady),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			required:         map[string]string{"cpu": "1000m"},
+			expectedValid:    false,
+			expectedContains: "insufficient cpu",
+		},
+		{
+			name: "healthy cluster with sufficient resources",
+			cluster: &clusterv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Status: clusterv1alpha1.ClusterStatus{
+					Allocatable: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("2000m"),
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(clusterv1alpha1.ClusterConditionReady),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			required:      map[string]string{"cpu": "1000m"},
+			expectedValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, msg := ValidateClusterCapacity(tt.cluster, tt.required)
+			if valid != tt.expectedValid {
+				t.Errorf("expected valid=%v, got=%v, msg=%v", tt.expectedValid, valid, msg)
+			}
+			if !tt.expectedValid && tt.expectedContains != "" && !strings.Contains(strings.ToLower(msg), strings.ToLower(tt.expectedContains)) {
+				t.Errorf("expected message to contain %q, got=%q", tt.expectedContains, msg)
+			}
+		})
+	}
+}
+
+func TestIsClusterSchedulable(t *testing.T) {
+	tests := []struct {
+		name              string
+		cluster           *clusterv1alpha1.Cluster
+		expectedScheduled bool
+	}{
+		{
+			name:              "nil cluster",
+			cluster:           nil,
+			expectedScheduled: false,
+		},
+		{
+			name: "unschedulable cluster by taint",
+			cluster: &clusterv1alpha1.Cluster{
+				Spec: clusterv1alpha1.ClusterSpec{
+					Taints: []corev1.Taint{
+						{Key: ClusterUnschedulableTaintKey},
+					},
+				},
+			},
+			expectedScheduled: false,
+		},
+		{
+			name: "schedulable healthy cluster",
+			cluster: &clusterv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "healthy-cluster"},
+				Status: clusterv1alpha1.ClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(clusterv1alpha1.ClusterConditionReady),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedScheduled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if IsClusterSchedulable(tt.cluster) != tt.expectedScheduled {
+				t.Errorf("expected=%v, got=%v", tt.expectedScheduled, IsClusterSchedulable(tt.cluster))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Adds reusable validation functions for cluster scheduling decisions:
- ValidateClusterCapacity: Check if cluster has sufficient resources
- IsClusterSchedulable: Verify cluster is ready and not tainted
- GetClusterScheduleScore: Calculate scheduling priority score
- GetClusterReadyTime: Track when cluster became ready