### PR TITLE
fix: prevent nil ResourceSummary panic in dispatcher Snapshot

### DIFF
--- a/pkg/dispatcher/cache/event_handlers.go
+++ b/pkg/dispatcher/cache/event_handlers.go
@@ -304,6 +304,16 @@ func (dc *DispatcherCache) updateCluster(oldObj, newObj interface{}) {
 	dc.mutex.Lock()
 	defer dc.mutex.Unlock()
 
+	if ready, message := utils.CheckClusterReady(newCluster); !ready {
+		klog.V(5).Info(message)
+		delete(dc.clusters, newCluster.Name)
+		return
+	}
+	if newCluster.Status.ResourceSummary == nil {
+		klog.V(5).Infof("Cluster <%s> has nil ResourceSummary, removing it from cache.", newCluster.Name)
+		delete(dc.clusters, newCluster.Name)
+		return
+	}
 	dc.setCluster(newCluster)
 }
 

--- a/pkg/dispatcher/cache/snapshot.go
+++ b/pkg/dispatcher/cache/snapshot.go
@@ -57,6 +57,10 @@ func (dc *DispatcherCache) Snapshot() *DispatcherCacheSnapshot {
 	}
 
 	for _, cluster := range dc.clusters {
+		if cluster.Status.ResourceSummary == nil {
+			klog.V(5).Infof("Cluster <%s> has nil ResourceSummary, skipping resource aggregation.", cluster.Name)
+			continue
+		}
 		snapshot.TotalResource.Add(schedulingapi.NewResource(cluster.Status.ResourceSummary.Allocatable))
 	}
 


### PR DESCRIPTION

## Description
I'm fixing a critical crash loop in the dispatcher. Basically, I found that if a member cluster becomes unhealthy or reports an empty status, the whole controller panics due to a nil pointer dereference.

Specifically, this PR:
1.  **Guards `updateCluster`**: I made sure we stop caching "NotReady" clusters or ones with missing `ResourceSummary`.
2.  **Protects `Snapshot()`**: I added a safety check in the snapshot loop so we don't crash even if bad data somehow sneaks into the cache.

## Why is it needed?
I ran into this while debugging some unstable cluster scenarios. I noticed that while `addCluster` correctly checks `CheckClusterReady`, **`updateCluster` was missing this check entirely**.

So, if a cluster transitioned from `Ready` -> `NotReady` (or if its `ResourceSummary` got cleared), `updateCluster` was blindly keeping that bad state in the cache.

Later on, when `Snapshot()` runs, it iterates over the cache and tries to read `cluster.Status.ResourceSummary.Allocatable`. Since `ResourceSummary` is nil, the dispatcher panics. This kills the process and stops all workload scheduling until someone manually fixes the bad cluster.

## The Fix Details

### 1. `pkg/dispatcher/cache/event_handlers.go`
I updated `updateCluster` to match the logic we already have in `addCluster`.
* **Before:** It blindly updated the cache with whatever the informer sent.
* **After:** Now it actually calls `utils.CheckClusterReady(newCluster)`. If the cluster isn't ready anymore, I explicitly **remove** it from the cache to keep things clean.

### 2. `pkg/dispatcher/cache/snapshot.go`
I added a nil guard inside the `Snapshot()` loop as a backup.
* **Before:** It assumed `cluster.Status.ResourceSummary` was always valid.
* **After:** It checks if `ResourceSummary` is nil first. If it is, I just skip that cluster and log a warning so the dispatcher stays alive.
