### PR TITLE
fix: prevent nil Locality panic in periodic DataSource update

### DIFF
--- a/pkg/controller/datadependency/plugin_manager.go
+++ b/pkg/controller/datadependency/plugin_manager.go
@@ -482,15 +482,13 @@ func (pm *PluginManager) updateSingleDataSource(ctx context.Context, ds *v1alpha
         return
     }
 
-	// Update DataSource spec if clusters have changed
-	var currentClusters []string
-	if ds.Spec.Locality != nil {
-		currentClusters = ds.Spec.Locality.ClusterNames
+	// Ensure Locality is initialized before accessing ClusterNames
+	if ds.Spec.Locality == nil {
+		ds.Spec.Locality = &v1alpha1.DataSourceLocality{}
 	}
-	if !pm.clustersEqual(currentClusters, clusters) {
-		if ds.Spec.Locality == nil {
-			ds.Spec.Locality = &v1alpha1.DataSourceLocality{}
-		}
+
+	// Update DataSource spec if clusters have changed
+	if !pm.clustersEqual(ds.Spec.Locality.ClusterNames, clusters) {
 		ds.Spec.Locality.ClusterNames = clusters
 
 		_, err := pm.datadependencyClient.DatadependencyV1alpha1().DataSources().Update(ctx, ds, metav1.UpdateOptions{})

--- a/pkg/controller/datadependency/plugin_manager.go
+++ b/pkg/controller/datadependency/plugin_manager.go
@@ -483,7 +483,14 @@ func (pm *PluginManager) updateSingleDataSource(ctx context.Context, ds *v1alpha
     }
 
 	// Update DataSource spec if clusters have changed
-	if !pm.clustersEqual(ds.Spec.Locality.ClusterNames, clusters) {
+	var currentClusters []string
+	if ds.Spec.Locality != nil {
+		currentClusters = ds.Spec.Locality.ClusterNames
+	}
+	if !pm.clustersEqual(currentClusters, clusters) {
+		if ds.Spec.Locality == nil {
+			ds.Spec.Locality = &v1alpha1.DataSourceLocality{}
+		}
 		ds.Spec.Locality.ClusterNames = clusters
 
 		_, err := pm.datadependencyClient.DatadependencyV1alpha1().DataSources().Update(ctx, ds, metav1.UpdateOptions{})


### PR DESCRIPTION
## The Bug
I ran into a critical issue where the entire `volcano-global-controller-manager` crashes and gets permanently stuck in a `CrashLoopBackOff`. It turns out that if a `DataSource` object is created without a `Locality` field (which is a perfectly valid state since it's an optional `*DataSourceLocality` pointer in the CRD), the background goroutine in `StartPeriodicUpdate` trips over a nil pointer dereference at `plugin_manager.go:486`. 

Because this panic happens in a background goroutine without a `recover()` catch, it takes the entire controller-manager process down with it. 

## The Fix
I added a straightforward nil guard inside `updateSingleDataSource` before we attempt to evaluate `ds.Spec.Locality.ClusterNames`. Now, if `Locality` is `nil`, we simply initialize it safely before assigning the new cluster list. 

We actually already handle this exact scenario correctly over in `pkg/controller/datadependency/reconciler.go:528` (`if ds.Spec.Locality != nil`), so this PR basically just ports that same established defensive pattern to the plugin manager where it was accidentally missed.

## Why this matters 
This is a vital stability fix for production environments. Before this, a single malformed `DataSource` object—whether created manually, during an API migration, or by a buggy operator—would silently kill the dispatcher, the HyperJob reconciler, and the DataDependency controller all at once. This effectively halted all batch workloads depending on the dispatcher. This PR ensures the controller gracefully handles the missing locality edge case without tanking the rest of the system.