### PR TITLE
env-setup:  add scripts to bootstrap Karmada, Volcano, and deploy volcano-global

### DIFF
--- a/hack/deploy-volcano-global.sh
+++ b/hack/deploy-volcano-global.sh
@@ -25,7 +25,7 @@ TAG=${TAG:-$(git rev-parse --verify HEAD 2>/dev/null || echo "latest")}
 IMAGE_PREFIX=${IMAGE_PREFIX:-"volcanosh"}
 KARMADA_KUBECONFIG=${KARMADA_KUBECONFIG:-"${HOME}/.kube/karmada.config"}
 KARMADA_HOST_CLUSTER=${KARMADA_HOST_CLUSTER:-"karmada-host"}
-VOLCANO_VERSION=${VOLCANO_VERSION:-"release-1.10"}
+VOLCANO_VERSION=${VOLCANO_VERSION:-"release-1.14"}
 SKIP_BUILD=${SKIP_BUILD:-"false"}
 
 CONTROLLER_MANAGER_IMAGE="${IMAGE_PREFIX}/volcano-global-controller-manager:${TAG}"

--- a/hack/deploy-volcano-global.sh
+++ b/hack/deploy-volcano-global.sh
@@ -48,6 +48,31 @@ ensure_exists() {
     fi
 }
 
+kind_load_image() {
+    local image="$1"
+    local cluster_name="$2"
+
+    if ! kind get clusters 2>/dev/null | grep -qx "${cluster_name}"; then
+        echo "ERROR: Kind cluster '${cluster_name}' not found. Did you run hack/setup-karmada.sh?"
+        exit 1
+    fi
+
+    local attempt=1
+    local max_attempts=3
+    while [ "${attempt}" -le "${max_attempts}" ]; do
+        if kind load docker-image "${image}" --name "${cluster_name}"; then
+            return 0
+        fi
+        echo "WARN: Failed to load image '${image}' into Kind '${cluster_name}' (attempt ${attempt}/${max_attempts})"
+        attempt=$((attempt + 1))
+        sleep 2
+    done
+
+    echo "ERROR: Unable to load image '${image}' into Kind cluster '${cluster_name}'."
+    echo "ERROR: Check that the image exists locally and the Kind cluster is running."
+    exit 1
+}
+
 echo "=== Deploying Volcano-Global ==="
 echo "Image tag: ${TAG}"
 echo "Controller image: ${CONTROLLER_MANAGER_IMAGE}"
@@ -63,8 +88,8 @@ fi
 
 # Step 2: Load images into the karmada-host Kind cluster
 echo "Loading images into Kind cluster ${KARMADA_HOST_CLUSTER}..."
-kind load docker-image "${CONTROLLER_MANAGER_IMAGE}" --name "${KARMADA_HOST_CLUSTER}" 2>/dev/null || true
-kind load docker-image "${WEBHOOK_MANAGER_IMAGE}" --name "${KARMADA_HOST_CLUSTER}" 2>/dev/null || true
+kind_load_image "${CONTROLLER_MANAGER_IMAGE}" "${KARMADA_HOST_CLUSTER}"
+kind_load_image "${WEBHOOK_MANAGER_IMAGE}" "${KARMADA_HOST_CLUSTER}"
 
 export KUBECONFIG="${KARMADA_KUBECONFIG}"
 ensure_context "${KARMADA_HOST_CLUSTER}"
@@ -87,18 +112,12 @@ ensure_exists "${KARMADA_HOST_CLUSTER}" -n karmada-system get secret karmada-web
 echo "Applying CRDs to Karmada API server..."
 kubectl --context karmada-apiserver apply -f docs/deploy/training.volcano.sh_hyperjobs.yaml
 kubectl --context karmada-apiserver apply -f \
-    "https://github.com/volcano-sh/volcano/raw/${VOLCANO_VERSION}/installer/helm/chart/volcano/crd/bases/batch.volcano.sh_jobs.yaml"
+    "https://raw.githubusercontent.com/volcano-sh/volcano/${VOLCANO_VERSION}/installer/helm/chart/volcano/crd/bases/batch.volcano.sh_jobs.yaml"
 kubectl --context karmada-apiserver apply -f \
-    "https://github.com/volcano-sh/volcano/raw/${VOLCANO_VERSION}/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_queues.yaml"
+    "https://raw.githubusercontent.com/volcano-sh/volcano/${VOLCANO_VERSION}/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_queues.yaml"
 ensure_exists "karmada-apiserver" get crd hyperjobs.training.volcano.sh
 ensure_exists "karmada-apiserver" get crd jobs.batch.volcano.sh
 ensure_exists "karmada-apiserver" get crd queues.scheduling.volcano.sh
-
-# Apply DataDependency CRDs if present
-if [ -d "docs/deploy/crds" ]; then
-    echo "Applying DataDependency CRDs..."
-    kubectl --context karmada-apiserver apply -f docs/deploy/crds/
-fi
 
 # Step 5: Deploy volcano-global controller and webhook manager
 echo "Creating volcano-global namespace..."

--- a/hack/deploy-volcano-global.sh
+++ b/hack/deploy-volcano-global.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}"
+
+TAG=${TAG:-$(git rev-parse --verify HEAD 2>/dev/null || echo "latest")}
+IMAGE_PREFIX=${IMAGE_PREFIX:-"volcanosh"}
+KARMADA_KUBECONFIG=${KARMADA_KUBECONFIG:-"${HOME}/.kube/karmada.config"}
+KARMADA_HOST_CLUSTER=${KARMADA_HOST_CLUSTER:-"karmada-host"}
+VOLCANO_VERSION=${VOLCANO_VERSION:-"release-1.10"}
+SKIP_BUILD=${SKIP_BUILD:-"false"}
+
+CONTROLLER_MANAGER_IMAGE="${IMAGE_PREFIX}/volcano-global-controller-manager:${TAG}"
+WEBHOOK_MANAGER_IMAGE="${IMAGE_PREFIX}/volcano-global-webhook-manager:${TAG}"
+
+ensure_context() {
+    local context="$1"
+    if ! kubectl config get-contexts "${context}" >/dev/null 2>&1; then
+        echo "ERROR: Missing kubeconfig context '${context}'"
+        exit 1
+    fi
+}
+
+ensure_exists() {
+    local context="$1"
+    shift
+    if ! kubectl --context "${context}" "$@" >/dev/null 2>&1; then
+        echo "ERROR: Validation failed: kubectl --context ${context} $*"
+        exit 1
+    fi
+}
+
+echo "=== Deploying Volcano-Global ==="
+echo "Image tag: ${TAG}"
+echo "Controller image: ${CONTROLLER_MANAGER_IMAGE}"
+echo "Webhook image: ${WEBHOOK_MANAGER_IMAGE}"
+
+# Step 1: Build images
+if [ "${SKIP_BUILD}" != "true" ]; then
+    echo "Building volcano-global images..."
+    make images TAG="${TAG}"
+else
+    echo "Skipping image build (SKIP_BUILD=true)"
+fi
+
+# Step 2: Load images into the karmada-host Kind cluster
+echo "Loading images into Kind cluster ${KARMADA_HOST_CLUSTER}..."
+kind load docker-image "${CONTROLLER_MANAGER_IMAGE}" --name "${KARMADA_HOST_CLUSTER}" 2>/dev/null || true
+kind load docker-image "${WEBHOOK_MANAGER_IMAGE}" --name "${KARMADA_HOST_CLUSTER}" 2>/dev/null || true
+
+export KUBECONFIG="${KARMADA_KUBECONFIG}"
+ensure_context "${KARMADA_HOST_CLUSTER}"
+ensure_context "karmada-apiserver"
+
+# Step 3: Deploy Kubernetes Reflector to share kubeconfig secret
+echo "Deploying Kubernetes Reflector..."
+kubectl --context "${KARMADA_HOST_CLUSTER}" -n kube-system apply -f \
+    https://github.com/emberstack/kubernetes-reflector/releases/download/v7.1.262/reflector.yaml
+
+echo "Annotating karmada-webhook-config secret for reflection..."
+kubectl --context "${KARMADA_HOST_CLUSTER}" annotate secret karmada-webhook-config \
+    reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces="volcano-global" \
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true" \
+    --namespace=karmada-system --overwrite
+ensure_exists "${KARMADA_HOST_CLUSTER}" -n karmada-system get secret karmada-webhook-config
+
+# Step 4: Apply CRDs to Karmada API server
+echo "Applying CRDs to Karmada API server..."
+kubectl --context karmada-apiserver apply -f docs/deploy/training.volcano.sh_hyperjobs.yaml
+kubectl --context karmada-apiserver apply -f \
+    "https://github.com/volcano-sh/volcano/raw/${VOLCANO_VERSION}/installer/helm/chart/volcano/crd/bases/batch.volcano.sh_jobs.yaml"
+kubectl --context karmada-apiserver apply -f \
+    "https://github.com/volcano-sh/volcano/raw/${VOLCANO_VERSION}/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_queues.yaml"
+ensure_exists "karmada-apiserver" get crd hyperjobs.training.volcano.sh
+ensure_exists "karmada-apiserver" get crd jobs.batch.volcano.sh
+ensure_exists "karmada-apiserver" get crd queues.scheduling.volcano.sh
+
+# Apply DataDependency CRDs if present
+if [ -d "docs/deploy/crds" ]; then
+    echo "Applying DataDependency CRDs..."
+    kubectl --context karmada-apiserver apply -f docs/deploy/crds/
+fi
+
+# Step 5: Deploy volcano-global controller and webhook manager
+echo "Creating volcano-global namespace..."
+kubectl --context karmada-apiserver apply -f docs/deploy/volcano-global-namespace.yaml
+kubectl --context "${KARMADA_HOST_CLUSTER}" apply -f docs/deploy/volcano-global-namespace.yaml
+
+echo "Waiting for kubeconfig secret to be reflected to volcano-global namespace..."
+RETRY_COUNT=0
+MAX_RETRIES=60
+until kubectl --context "${KARMADA_HOST_CLUSTER}" -n volcano-global get secret karmada-webhook-config &>/dev/null; do
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ ${RETRY_COUNT} -ge ${MAX_RETRIES} ]; then
+        echo "ERROR: Kubeconfig secret was not reflected to volcano-global namespace"
+        exit 1
+    fi
+    echo "Waiting for kubeconfig secret reflection... (${RETRY_COUNT}/${MAX_RETRIES})"
+    sleep 5
+done
+ensure_exists "${KARMADA_HOST_CLUSTER}" -n volcano-global get secret karmada-webhook-config
+
+echo "Deploying volcano-global controller-manager..."
+sed "s|image: .*volcano-global-controller-manager:.*|image: ${CONTROLLER_MANAGER_IMAGE}|" \
+    docs/deploy/volcano-global-controller-manager.yaml | \
+    sed "s|imagePullPolicy: .*|imagePullPolicy: IfNotPresent|" | \
+    kubectl --context "${KARMADA_HOST_CLUSTER}" apply -f -
+
+echo "Deploying volcano-global webhook-manager..."
+sed "s|image: .*volcano-global-webhook-manager:.*|image: ${WEBHOOK_MANAGER_IMAGE}|" \
+    docs/deploy/volcano-global-webhook-manager.yaml | \
+    sed "s|imagePullPolicy: .*|imagePullPolicy: IfNotPresent|" | \
+    kubectl --context "${KARMADA_HOST_CLUSTER}" apply -f -
+
+echo "Applying webhook configuration..."
+kubectl --context karmada-apiserver apply -f docs/deploy/volcano-global-webhooks.yaml
+ensure_exists "karmada-apiserver" get mutatingwebhookconfiguration volcano-admission-service-resourcebindings-mutate
+ensure_exists "karmada-apiserver" get mutatingwebhookconfiguration volcano-admission-service-jobs-mutate
+ensure_exists "karmada-apiserver" get validatingwebhookconfiguration volcano-admission-service-jobs-validate
+
+# Step 6: Apply resource interpreters
+echo "Applying resource interpreters..."
+kubectl --context karmada-apiserver apply -f docs/deploy/vcjob-resource-interpreter-customization.yaml
+kubectl --context karmada-apiserver apply -f docs/deploy/queue-resource-interpreter-customization.yaml
+ensure_exists "karmada-apiserver" get resourceinterpretercustomization vcjob-configuration
+ensure_exists "karmada-apiserver" get resourceinterpretercustomization queue-configuration
+
+# Step 7: Apply queue propagation policy
+echo "Applying all-queue propagation policy..."
+kubectl --context karmada-apiserver apply -f docs/deploy/volcano-global-all-queue-propagation.yaml
+kubectl --context karmada-apiserver label clusterpropagationpolicy volcano-global-all-queue-propagation \
+    resourcetemplate.karmada.io/deletion-protected=Always --overwrite
+ensure_exists "karmada-apiserver" get clusterpropagationpolicy volcano-global-all-queue-propagation
+actual_label=$(kubectl --context karmada-apiserver get clusterpropagationpolicy volcano-global-all-queue-propagation \
+    -o jsonpath='{.metadata.labels.resourcetemplate\.karmada\.io/deletion-protected}')
+if [ "${actual_label}" != "Always" ]; then
+    echo "ERROR: Expected deletion-protected label to be 'Always', got '${actual_label}'"
+    exit 1
+fi
+
+# Wait for volcano-global deployments to be ready
+echo "Waiting for volcano-global deployments to be ready..."
+kubectl --context "${KARMADA_HOST_CLUSTER}" -n volcano-global wait --for=condition=Available deployment --all --timeout=300s
+
+echo "=== Volcano-Global deployed successfully ==="
+kubectl --context "${KARMADA_HOST_CLUSTER}" -n volcano-global get pods

--- a/hack/setup-e2e-env.sh
+++ b/hack/setup-e2e-env.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}"
+
+echo "=== Setup E2E Environment ==="
+
+./hack/setup-karmada.sh
+./hack/setup-volcano.sh
+./hack/deploy-volcano-global.sh
+
+echo "=== E2E environment is ready ==="

--- a/hack/setup-karmada.sh
+++ b/hack/setup-karmada.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KARMADA_REPO=${KARMADA_REPO:-"https://github.com/karmada-io/karmada.git"}
+KARMADA_DIR=${KARMADA_DIR:-"/tmp/karmada"}
+
+echo "=== Setting up Karmada multi-cluster environment ==="
+
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: Docker engine is not reachable. Please start Docker Desktop and try again."
+    exit 1
+fi
+
+# Step 1: Clone the Karmada repo
+if [ -d "${KARMADA_DIR}" ]; then
+    echo "Karmada directory already exists at ${KARMADA_DIR}, removing..."
+    rm -rf "${KARMADA_DIR}"
+fi
+
+echo "Cloning Karmada repository..."
+git clone "${KARMADA_REPO}" "${KARMADA_DIR}"
+
+# Step 2: cd into it
+cd "${KARMADA_DIR}"
+
+# Step 3: Deploy the Karmada environment
+echo "Running Karmada local-up script..."
+./hack/local-up-karmada.sh
+
+# Verify the environment came up
+echo "Verifying Karmada API server..."
+export KUBECONFIG="${HOME}/.kube/karmada.config"
+kubectl --context karmada-apiserver get ns default >/dev/null
+echo "Karmada API server is healthy."
+
+echo "Verifying member clusters..."
+export KUBECONFIG="${HOME}/.kube/members.config"
+for cluster in member1 member2 member3; do
+    kubectl --context "${cluster}" get ns default >/dev/null
+    echo "  ${cluster} is ready."
+done
+
+echo "=== Karmada multi-cluster environment is ready ==="
+echo "  Karmada config: ${HOME}/.kube/karmada.config"
+echo "  Members config: ${HOME}/.kube/members.config"
+echo "  Contexts: karmada-host, karmada-apiserver, member1, member2, member3"

--- a/hack/setup-karmada.sh
+++ b/hack/setup-karmada.sh
@@ -47,6 +47,9 @@ echo "Running Karmada local-up script..."
 # Verify the environment came up
 echo "Verifying Karmada API server..."
 export KUBECONFIG="${HOME}/.kube/karmada.config"
+kubectl config get-contexts karmada-host >/dev/null
+kubectl --context karmada-host get ns default >/dev/null
+echo "Karmada host cluster is healthy."
 kubectl --context karmada-apiserver get ns default >/dev/null
 echo "Karmada API server is healthy."
 

--- a/hack/setup-karmada.sh
+++ b/hack/setup-karmada.sh
@@ -49,6 +49,9 @@ curl -sL "${KARMADA_TARBALL_URL}" | tar xz --strip-components=1 -C "${KARMADA_DI
 cd "${KARMADA_DIR}"
 
 # Step 3: Deploy the Karmada environment
+# Disable Go VCS stamping: the tarball has no .git directory, so `go build`
+# would otherwise fail with "error obtaining VCS status: exit status 128".
+export GOFLAGS="${GOFLAGS:-} -buildvcs=false"
 echo "Running Karmada local-up script..."
 ./hack/local-up-karmada.sh
 

--- a/hack/setup-karmada.sh
+++ b/hack/setup-karmada.sh
@@ -18,24 +18,32 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KARMADA_REPO=${KARMADA_REPO:-"https://github.com/karmada-io/karmada.git"}
+KARMADA_VERSION=${KARMADA_VERSION:-"v1.12.0"}
 KARMADA_DIR=${KARMADA_DIR:-"/tmp/karmada"}
+KARMADA_TARBALL_URL="https://github.com/karmada-io/karmada/archive/refs/tags/${KARMADA_VERSION}.tar.gz"
+MEMBER_CLUSTERS=${MEMBER_CLUSTERS:-"member1 member2 member3"}
 
 echo "=== Setting up Karmada multi-cluster environment ==="
+echo "Karmada version: ${KARMADA_VERSION}"
 
 if ! docker info >/dev/null 2>&1; then
     echo "ERROR: Docker engine is not reachable. Please start Docker Desktop and try again."
     exit 1
 fi
 
-# Step 1: Clone the Karmada repo
+# Step 1: Download and extract the Karmada release tarball
 if [ -d "${KARMADA_DIR}" ]; then
     echo "Karmada directory already exists at ${KARMADA_DIR}, removing..."
     rm -rf "${KARMADA_DIR}"
 fi
 
-echo "Cloning Karmada repository..."
-git clone --depth 1 "${KARMADA_REPO}" "${KARMADA_DIR}"
+echo "Downloading Karmada ${KARMADA_VERSION}"
+mkdir -p "${KARMADA_DIR}"
+curl -sL "${KARMADA_TARBALL_URL}" | tar xz --strip-components=1 -C "${KARMADA_DIR}" || {
+    echo "ERROR: Failed to download Karmada tarball from '${KARMADA_TARBALL_URL}'"
+    echo "ERROR: Please verify KARMADA_VERSION points to an existing release tag."
+    exit 1
+}
 
 # Step 2: cd into it
 cd "${KARMADA_DIR}"
@@ -47,15 +55,11 @@ echo "Running Karmada local-up script..."
 # Verify the environment came up
 echo "Verifying Karmada API server..."
 export KUBECONFIG="${HOME}/.kube/karmada.config"
-kubectl config get-contexts karmada-host >/dev/null
-kubectl --context karmada-host get ns default >/dev/null
-echo "Karmada host cluster is healthy."
 kubectl --context karmada-apiserver get ns default >/dev/null
 echo "Karmada API server is healthy."
 
 echo "Verifying member clusters..."
 export KUBECONFIG="${HOME}/.kube/members.config"
-MEMBER_CLUSTERS=${MEMBER_CLUSTERS:-"member1 member2 member3"}
 for cluster in ${MEMBER_CLUSTERS}; do
     kubectl --context "${cluster}" get ns default >/dev/null
     echo "  ${cluster} is ready."

--- a/hack/setup-karmada.sh
+++ b/hack/setup-karmada.sh
@@ -35,7 +35,7 @@ if [ -d "${KARMADA_DIR}" ]; then
 fi
 
 echo "Cloning Karmada repository..."
-git clone "${KARMADA_REPO}" "${KARMADA_DIR}"
+git clone --depth 1 "${KARMADA_REPO}" "${KARMADA_DIR}"
 
 # Step 2: cd into it
 cd "${KARMADA_DIR}"

--- a/hack/setup-karmada.sh
+++ b/hack/setup-karmada.sh
@@ -52,7 +52,8 @@ echo "Karmada API server is healthy."
 
 echo "Verifying member clusters..."
 export KUBECONFIG="${HOME}/.kube/members.config"
-for cluster in member1 member2 member3; do
+MEMBER_CLUSTERS=${MEMBER_CLUSTERS:-"member1 member2 member3"}
+for cluster in ${MEMBER_CLUSTERS}; do
     kubectl --context "${cluster}" get ns default >/dev/null
     echo "  ${cluster} is ready."
 done

--- a/hack/setup-volcano.sh
+++ b/hack/setup-volcano.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VOLCANO_VERSION=${VOLCANO_VERSION:-"release-1.10"}
+VOLCANO_INSTALL_URL="https://raw.githubusercontent.com/volcano-sh/volcano/${VOLCANO_VERSION}/installer/volcano-development.yaml"
+MEMBER_CLUSTERS=${MEMBER_CLUSTERS:-"member1 member2 member3"}
+MEMBERS_KUBECONFIG=${MEMBERS_KUBECONFIG:-"${HOME}/.kube/members.config"}
+
+echo "=== Installing Volcano on member clusters ==="
+echo "Volcano version: ${VOLCANO_VERSION}"
+echo "Member clusters: ${MEMBER_CLUSTERS}"
+
+export KUBECONFIG="${MEMBERS_KUBECONFIG}"
+
+for cluster in ${MEMBER_CLUSTERS}; do
+    echo "Installing Volcano on ${cluster}..."
+    kubectl --context "${cluster}" apply -f "${VOLCANO_INSTALL_URL}"
+done
+
+echo "Waiting for Volcano pods to be ready on each member cluster..."
+MAX_RETRIES=60
+for cluster in ${MEMBER_CLUSTERS}; do
+    echo "Checking Volcano readiness on ${cluster}..."
+    RETRY_COUNT=0
+    until kubectl --context "${cluster}" -n volcano-system get pods 2>/dev/null | grep -q "Running"; do
+        RETRY_COUNT=$((RETRY_COUNT + 1))
+        if [ ${RETRY_COUNT} -ge ${MAX_RETRIES} ]; then
+            echo "ERROR: Volcano failed to become ready on ${cluster}"
+            kubectl --context "${cluster}" -n volcano-system get pods
+            exit 1
+        fi
+        echo "Waiting for Volcano on ${cluster}... (${RETRY_COUNT}/${MAX_RETRIES})"
+        sleep 5
+    done
+
+    kubectl --context "${cluster}" -n volcano-system wait --for=condition=Available deployment --all --timeout=300s || {
+        echo "ERROR: Volcano deployments on ${cluster} did not become ready in time"
+        kubectl --context "${cluster}" -n volcano-system get pods
+        exit 1
+    }
+    echo "Volcano is ready on ${cluster}."
+done
+
+echo "=== Volcano installed on all member clusters ==="

--- a/hack/setup-volcano.sh
+++ b/hack/setup-volcano.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VOLCANO_VERSION=${VOLCANO_VERSION:-"release-1.10"}
+VOLCANO_VERSION=${VOLCANO_VERSION:-"release-1.14"}
 VOLCANO_INSTALL_URL="https://raw.githubusercontent.com/volcano-sh/volcano/${VOLCANO_VERSION}/installer/volcano-development.yaml"
 MEMBER_CLUSTERS=${MEMBER_CLUSTERS:-"member1 member2 member3"}
 MEMBERS_KUBECONFIG=${MEMBERS_KUBECONFIG:-"${HOME}/.kube/members.config"}
@@ -35,20 +35,8 @@ for cluster in ${MEMBER_CLUSTERS}; do
 done
 
 echo "Waiting for Volcano pods to be ready on each member cluster..."
-MAX_RETRIES=60
 for cluster in ${MEMBER_CLUSTERS}; do
     echo "Checking Volcano readiness on ${cluster}..."
-    RETRY_COUNT=0
-    until kubectl --context "${cluster}" -n volcano-system get pods 2>/dev/null | grep -q "Running"; do
-        RETRY_COUNT=$((RETRY_COUNT + 1))
-        if [ ${RETRY_COUNT} -ge ${MAX_RETRIES} ]; then
-            echo "ERROR: Volcano failed to become ready on ${cluster}"
-            kubectl --context "${cluster}" -n volcano-system get pods
-            exit 1
-        fi
-        echo "Waiting for Volcano on ${cluster}... (${RETRY_COUNT}/${MAX_RETRIES})"
-        sleep 5
-    done
 
     kubectl --context "${cluster}" -n volcano-system wait --for=condition=Available deployment --all --timeout=300s || {
         echo "ERROR: Volcano deployments on ${cluster} did not become ready in time"


### PR DESCRIPTION
## Summary
This PR adds the **environment bootstrap + deployment automation** needed as the foundation for volcano-global end-to-end testing:
- Bootstrap a local Karmada multi-cluster environment (Kind-based, upstream flow)
- Install Volcano on member clusters
- Build/load volcano-global images and deploy required CRDs/manifests
- Provide a single orchestration script to run setup end-to-end

## Changes in this PR
- **`hack/setup-karmada.sh`**: bring up Karmada control plane + member clusters (Kind)
- **`hack/setup-volcano.sh`**: install Volcano on member clusters
- **`hack/deploy-volcano-global.sh`**: build/load images and apply `docs/deploy/*` + required CRDs/interpreters
- **`hack/setup-e2e-env.sh`**: orchestration wrapper that runs the above scripts in order

## Follow-up changes
- **E2E framework, runner, and dependencies**
  - Add Ginkgo/Gomega wiring, shared e2e framework utilities, runner scripts, and Go module deps
- **Test cases for all 4 scenarios**
  - Add suites for: resource quota & priority, cross-cluster VCJob scheduling, data-dependency aware scheduling, and HyperJob scheduling
- **CI workflow and documentation**
  - Add GitHub Actions workflow to run e2e in CI + docs for running/extending tests

## Test plan
- Run environment bootstrap:
  ```bash
  ./hack/setup-e2e-env.sh
  ```

- Verify volcano-global is running on the Karmada host cluster:
  ```bash
    export KUBECONFIG="$HOME/.kube/karmada.config" 
    kubectl --context karmada-host -n volcano-global get pods
    ```

- Verify required CRDs are installed in the Karmada API server:
  ```bash 
    export KUBECONFIG="$HOME/.kube/karmada.config"
    kubectl --context karmada-apiserver get crd | grep -E 'volcano|hyperjob'
    ```
  
## Liked issue:
- #35 